### PR TITLE
enable Pipeliner queue to grow while in progress

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -142,7 +142,7 @@
       this.delay = delay || 0;
       this.queue = [];
       this.n_out = 0;
-      this.cb = null;
+      this.cb = [];
       this[C.deferrals] = this;
       this["defer"] = this._defer;
     }
@@ -178,9 +178,9 @@
                   filename: "/Users/max/src/iced/iced-runtime/src/library.iced",
                   funcname: "Pipeliner.waitInQueue"
                 });
-                _this.cb = __iced_deferrals.defer({
+                _this.cb.push(__iced_deferrals.defer({
                   lineno: 100
-                });
+                }));
                 __iced_deferrals._fulfill();
               })(_next);
             }
@@ -214,7 +214,7 @@
     };
 
     Pipeliner.prototype.__defer = function(out, deferArgs) {
-      var tmp, voidCb, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var cb, voidCb, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       (function(_this) {
@@ -240,10 +240,10 @@
       })(this)((function(_this) {
         return function() {
           _this.n_out--;
-          if (_this.cb) {
-            tmp = _this.cb;
-            _this.cb = null;
-            return tmp();
+          if (_this.cb.length) {
+            while (cb = _this.cb.shift()) {
+              cb();
+            }
           }
         };
       })(this));
@@ -286,9 +286,9 @@
                 filename: "/Users/max/src/iced/iced-runtime/src/library.iced",
                 funcname: "Pipeliner.flush"
               });
-              _this.cb = __iced_deferrals.defer({
+              _this.cb.push(__iced_deferrals.defer({
                 lineno: 151
-              });
+              }));
               __iced_deferrals._fulfill();
             })(_next);
           }


### PR DESCRIPTION
The basic Pipeliner example fills the queue once, and then flushes it.  I propose that the queue should allow adding items while in-progress, while continuing to correctly limit outstanding calls.

This is actually how I imagined it should work, took me a bit to discover otherwise -- right now if `waitInQueue` is called after `flush`, the callback stored in `@cb` is overwritten and the queue will stop processing.  Simply changing `@cb` to a stack allows elements to continue to be added to the queue.  It also allows multiple callbacks to be attached (with `flush`) at any time the queue is processing, and fired when the queue is empty.

As a side effect, we are now able to watch the number of outstanding items in the queue, by checking the length of the `@cb` stack, and prevent unbounded backpressure in the queue.

I believe this change is backwards compatible, and will pass the current Pipeliner test in iced-coffee-script.  Are tests only run against the main repo?  I did not see any tests committed here.  If you can foresee any issues with this change I can revise it.

Thanks for this useful lib!

**EDIT: Example**

Here's how I'm using it now in awaitajax -- to [limit the number of outstanding http calls](https://github.com/doublerebel/node-awaitajax/blob/e8cf4116e68b6b1eeec245805cb90792a56131d5/src/ajax.iced#L30), while allowing more calls to stack in the queue.  [Here is the test](https://github.com/doublerebel/node-awaitajax/blob/e8cf4116e68b6b1eeec245805cb90792a56131d5/test/awaitajax.iced#L213) for that case.

**EDIT 2:**
Sidenote: While researching the cause of the issue, I noticed `@queue` seems to be completely unused in any published iced-coffee-script code.  I even checked TameJS and looks it's been there unused since first commit.  Is there a purpose for this instance variable, or is it a leftover artifact from the C translation?
