### PR TITLE
prevent collision with user defined variables names `iced`

### DIFF
--- a/src/const.iced
+++ b/src/const.iced
@@ -1,9 +1,9 @@
 
-module.exports = 
+module.exports =
   k : "__iced_k"
   k_noop : "__iced_k_noop"
   param : "__iced_p_"
-  ns: "iced"
+  ns: "__iced"
   runtime : "runtime"
   Deferrals : "Deferrals"
   deferrals : "__iced_deferrals"
@@ -30,4 +30,3 @@ module.exports =
   trampoline : "trampoline"
   context : "context"
   defer_arg : "__iced_defer_"
-


### PR DESCRIPTION
An impromptu fix for issue https://github.com/maxtaco/coffee-script/issues/160, so not tested yet.

Prefixing `iced` with underscores should decrease the likelihood of it being overshadowed.
