### PR TITLE
Do not call .next() on generator if it has not yielded.

### DIFF
--- a/src/runtime.iced
+++ b/src/runtime.iced
@@ -82,6 +82,7 @@ exports.Deferrals = class Deferrals
   constructor: (@iterator, @trace) ->
     @count = 0
     @ret = null
+    @yielded = false
 
   #----------
 
@@ -90,7 +91,8 @@ exports.Deferrals = class Deferrals
       __active_trace = trace
       i = @iterator
       @iterator = null
-      i.next(@ret)
+      if @yielded
+        i.next(@ret)
     else
       warn "Entered dead await at #{_trace_to_string trace}"
 
@@ -106,6 +108,7 @@ exports.Deferrals = class Deferrals
       @iterator = null
       return false
     else
+      @yielded = true
       return true
 
   #----------
@@ -142,7 +145,7 @@ exports.Rendezvous = class Rendezvous
   # RvId -- A helper class the allows deferalls to take on an ID
   # when used with Rendezvous
   class RvId
-    constructor: (@rv,@id,@multi)->
+    constructor: (@rv,@id,@multi) ->
     defer: (defer_args) ->
       @rv._defer_with_id @id, defer_args, @multi
 


### PR DESCRIPTION
Deferrals._call will not call .next() if await_exit was not called
yet. This fixes functions that are not deferred and just callback
immediately.

Consider this test:

```
atest 'can return immediately from awaited func', (cb) ->
  func = (cb) ->
    cb()

  await func defer()
  cb true, {}
```

without this patch, it would fail with:

```
TypeError: Generator is already running
  at [object Generator].next (native)
  at Deferrals.exports.Deferrals.Deferrals._call (/home/zapu/iced_es6/iced-runtime/lib/runtime.js:87:18)
  at Deferrals.exports.Deferrals.Deferrals._fulfill (/home/zapu/iced_es6/iced-runtime/lib/runtime.js:95:21)
```
